### PR TITLE
ChatGee mac 용 shell script

### DIFF
--- a/chatGee_mac_setting.sh
+++ b/chatGee_mac_setting.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+echo "꼭 chatGee 폴더 내부에서 실행해주세요"
+
+echo "1. HomeBrew Install"
+$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)
+
+echo $(brew --version)
+
+echo "2. 파이썬 3.10.10 설치"
+brew install python@3.10.10
+
+echo "3. python pip upgrade"
+python3 -m ensurepip --upgrade
+
+echo "4. 파이썬 가상환경 설정 - 오래걸릴 수 있습니다."
+pip3 install virtualenv
+
+echo "4-1 파이썬 가상환경을 생성합니다."
+python3 -m venv venv_chatgee
+
+echo "4-2 파이썬 가상환경을 실행합니다."
+source venv_chatgee/bin/activate
+
+echo "4-3 requirements.txt 기반으로 chatGee 에 필요한 파일을 설치합니다."
+pip3 install -r requirements.txt
+
+exit 0
+

--- a/chatGee_mac_start_stop.sh
+++ b/chatGee_mac_start_stop.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+echo "chatGee 시작 시 start 종료시 end 를 입력해주세요."
+echo "localhost.run 을 통해 주소를 발급받습니다. 발급된 주소를 running_log.out 에서 확인해주세요."
+if [ -f localhost_run.pid ]; then
+    kill -9 `cat localhost_run.pid`
+else
+    nohup ssh -o StrictHostKeyChecking=no -R 80:localhost:6959 nokey@localhost.run > localhost_run_log.out 2>&1 & echo $! > localhost_run.pid
+fi
+
+echo "챗지 프로세스를 시작하겠습니다"
+if [ "$1" = "start" ]; then
+    if [ -f chatgee.pid ]; then
+        kill -9 `cat chatgee.pid`
+    else
+        echo "챗지를 시작하겠습니다."
+        nohup python3 ./chatgee/run_server.py > running_log.out 2>&1 & echo $! > chatgee.pid
+    fi
+else
+    if [ -f chatgee.pid ]; then
+        kill -9 `cat chatgee.pid`
+        echo "챗지를 종료했습니다."
+    fi
+fi


### PR DESCRIPTION
윈도우 실행용 bat 파일만 있길래 
초보자를 위한 mac에서도 실행 가능한 shell script 첨부합니다.

1. chatGee_mac_setting.sh
- HomeBrew Install
- brew 를 통해 Python 3.10.10 설치
- python3 pip upgrade
- python 가상환경 설정
- python 가상환경 실행 & requirements.txt 설치

2. chatGee_mac_start_stop.sh
- localhost.run 을 실행하고 localhost_run_log.out 이라는 로그 파일을 남깁니다. 여기서 주소 확인이 가능합니다. (백그라운드 실행)
- chatGee/run_server.py 를 실행하고 running_log.out 이라는 로그 파일을 남깁니다. 여기서는 chatGee 의 실행 로그 확인이 가능합니다. (백그라운드 실행)
